### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/channelmartudis/961c847c-11f0-45d9-a1e3-fb6af59e5a58/b925acd8-2a96-48d3-8330-75861311b3ed/_apis/work/boardbadge/5ef1d115-5121-4cc3-9c0a-602e53b59bee)](https://dev.azure.com/channelmartudis/961c847c-11f0-45d9-a1e3-fb6af59e5a58/_boards/board/t/b925acd8-2a96-48d3-8330-75861311b3ed/Microsoft.RequirementCategory)
 # mainsaja
 Tempat main uang


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/channelmartudis/961c847c-11f0-45d9-a1e3-fb6af59e5a58/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.